### PR TITLE
Fix division by zero in colormap

### DIFF
--- a/Utils.py
+++ b/Utils.py
@@ -381,7 +381,12 @@ def apply_colormap(image):
         numpy.ndarray: The resulting false color image.
 
     """
-    normalized_image = (image - np.min(image)) / (np.max(image) - np.min(image))
+    min_val = np.min(image)
+    max_val = np.max(image)
+    if max_val == min_val:
+        normalized_image = np.zeros_like(image, dtype=np.float32)
+    else:
+        normalized_image = (image - min_val) / (max_val - min_val)
     colormap_image = cv2.applyColorMap((normalized_image * 255).astype(np.uint8), cv2.COLORMAP_JET)
     return colormap_image
 


### PR DESCRIPTION
## Summary
- avoid divide by zero when applying color map

## Testing
- `python -m py_compile Utils.py`
- `python -m py_compile RunInThermalDataset.py`
- `python -m py_compile derivative_utils.py`
- `python -m py_compile segmentation_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_683f99a125b8832da7f53c50ed2421c8