### PR TITLE
Add test for obtener_nombres_hdf5

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,18 @@ If there is no `.whl` file in the SDK, you will need to install it manually. Vis
    Next, locate the `.whl` file in the temporary directory (e.g., for Python 3.8 and AMD64) and install it:
 
    ```bash
+
    pip install .\FileSDK-4.1.0-cp38-cp38-win_amd64.whl
    ```
+
+### Running Tests
+
+The repository includes a small test suite located in the `tests/` folder.
+After installing the dependencies you can execute the tests with `pytest`:
+
+```bash
+pytest
+```
 
 ## Usage
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,55 @@
+import importlib.util
+import sys
+import types
+import unittest
+
+def load_derivative_utils():
+    # Stub external dependencies not available in the test environment
+    for name in ['flirimageextractor', 'flir_image_extractor', 'cv2', 'numpy', 'SimpleITK', 'Utils']:
+        sys.modules.setdefault(name, types.ModuleType(name))
+
+    matplotlib = types.ModuleType('matplotlib')
+    matplotlib.use = lambda *a, **k: None
+    pyplot = types.ModuleType('matplotlib.pyplot')
+    colors = types.ModuleType('matplotlib.colors')
+    matplotlib.pyplot = pyplot
+    matplotlib.colors = colors
+    sys.modules.setdefault('matplotlib', matplotlib)
+    sys.modules.setdefault('matplotlib.pyplot', pyplot)
+    sys.modules.setdefault('matplotlib.colors', colors)
+
+    sys.modules.setdefault('registration_simpleitk', types.ModuleType('registration_simpleitk'))
+
+    scipy = types.ModuleType('scipy')
+    interpolate = types.ModuleType('scipy.interpolate')
+    interpolate.interp1d = lambda *a, **k: None
+    scipy.interpolate = interpolate
+    sys.modules.setdefault('scipy', scipy)
+    sys.modules.setdefault('scipy.interpolate', interpolate)
+
+    spec = importlib.util.spec_from_file_location('derivative_utils', 'derivative_utils.py')
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+class TestObtenerNombresHdf5(unittest.TestCase):
+    def test_expected_names(self):
+        du = load_derivative_utils()
+        result = du.obtener_nombres_hdf5('flir_20230912T120000.jpg')
+        expected = (
+            'tr_right_20230912T120000.hdf5',
+            'tr_left_20230912T120000.hdf5',
+            'temp_right_20230912T120000.csv',
+            'temp_left_20230912T120000.csv',
+            'mask_right_20230912T120000.png',
+            'mask_left_20230912T120000.png',
+            'color_right_20230912T120000.png',
+            'color_left_20230912T120000.png',
+            'Raw_mask20230912T120000.png',
+            'Raw_RGB20230912T120000.png',
+            'Raw_temp20230912T120000.csv',
+        )
+        self.assertEqual(result, expected)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- create `tests/test_utils.py` with a unittest for `obtener_nombres_hdf5`
- document how to run the tests in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f9b843c38832d85702d370c777c95